### PR TITLE
Fixed mismatched key length in documentation

### DIFF
--- a/examples/encrypted_keyset/encrypted_keyset_cli.py
+++ b/examples/encrypted_keyset/encrypted_keyset_cli.py
@@ -56,7 +56,7 @@ def main(argv):
     logging.exception('Error creating GCP KMS client: %s', e)
     return 1
 
-  # Create envelope AEAD primitive using AES256 GCM for encrypting the data
+  # Create envelope AEAD primitive using AES128 GCM for encrypting the data
   try:
     remote_aead = client.get_aead(FLAGS.kek_uri)
   except tink.TinkError as e:


### PR DESCRIPTION
Updated the documentation advertising the creation of a 256-bit key, while the implementation below creates a 128-bit key. Note that in general, there are slight discrepancies between the examples in the developer documentation (https://developers.google.com/tink/) in the different languages, sometimes creating 128-bit keys and 256-bit keys otherwise.