### PR TITLE
Add toochain definition for Python 3.14.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,7 @@ python.toolchain(
 python.toolchain(python_version = "3.11")
 python.toolchain(python_version = "3.12")
 python.toolchain(python_version = "3.13")
+python.toolchain(python_version = "3.14")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
@@ -54,6 +55,11 @@ pip.parse(
 pip.parse(
     hub_name = "tink_py_pip_deps",
     python_version = "3.13",
+    requirements_lock = "@tink_py//:requirements_all.txt",
+)
+pip.parse(
+    hub_name = "tink_py_pip_deps",
+    python_version = "3.14",
     requirements_lock = "@tink_py//:requirements_all.txt",
 )
 use_repo(pip, "tink_py_pip_deps")


### PR DESCRIPTION
Why? This is required to build wheels for Python 3.14, part of #58.

The Python 3.14 build seems to just work. The Python 3.14 free-threaded version builds, but not working yet, at least on mac:

```bash
❯ python -c 'import sys; print(f"{sys.version=}")'
sys.version='3.14.2 free-threading build (main, Jan 17 2026, 20:47:02) [Clang 17.0.0 (clang-1700.6.3.2)]'
❯ python -c 'import tink'
[1]    6318 segmentation fault  python -c 'import tink'
```