### PR TITLE
fix(jwt): reject JWK Sets with duplicate JSON keys

### DIFF
--- a/tink/jwt/_jwk_set_converter.py
+++ b/tink/jwt/_jwk_set_converter.py
@@ -206,6 +206,25 @@ def _generate_unused_key_id(keyset: tink_pb2.Keyset) -> int:
       return key_id
 
 
+def _reject_duplicate_keys(pairs):
+  """object_pairs_hook for json.loads that rejects duplicate JSON keys.
+
+  Python's stdlib json.loads silently accepts duplicate JSON object keys
+  by last-value-wins; the sibling Tink ports (tink-cc, tink-go, tink-java)
+  use protobuf JSON parsers that strict-reject duplicate keys per RFC 8259
+  best practice. This hook brings tink-py's JWK Set parser to the same
+  strict behavior so a JWK Set that round-trips through tink-py and a
+  sibling port produces the same accept/reject decision.
+  """
+  seen = set()
+  for k, _ in pairs:
+    if k in seen:
+      raise tink.TinkError(
+          'invalid JWK set: duplicate JSON key %r' % k)
+    seen.add(k)
+  return dict(pairs)
+
+
 def to_public_keyset_handle(jwk_set: str) -> tink.KeysetHandle:
   """Converts a Json Web Key (JWK) set into a Tink KeysetHandle with JWT keys.
 
@@ -226,7 +245,7 @@ def to_public_keyset_handle(jwk_set: str) -> tink.KeysetHandle:
     TinkError if the key cannot be converted.
   """
   try:
-    keys_dict = json.loads(jwk_set)
+    keys_dict = json.loads(jwk_set, object_pairs_hook=_reject_duplicate_keys)
   except json.decoder.JSONDecodeError as e:
     raise tink.TinkError('error parsing JWK set: %s' % e.msg)
   if 'keys' not in keys_dict:

--- a/tink/jwt/_jwk_set_converter.py
+++ b/tink/jwt/_jwk_set_converter.py
@@ -206,6 +206,37 @@ def _generate_unused_key_id(keyset: tink_pb2.Keyset) -> int:
       return key_id
 
 
+def _get_required_str(key: Dict, name: str) -> str:
+  """Reads key[name], rejecting non-string types with tink.TinkError.
+
+  Without this helper, json.loads can produce non-str values (None, int,
+  list, dict, bool) for fields the spec requires to be strings, and the
+  downstream call sites (str.startswith, str.encode, protobuf string
+  assignment) raise AttributeError or TypeError instead of the
+  tink.TinkError documented as the only exception of to_public_keyset_handle.
+  """
+  if name not in key:
+    raise tink.TinkError('invalid JWK: %r not found' % name)
+  value = key[name]
+  if not isinstance(value, str):
+    raise tink.TinkError(
+        'invalid JWK: field %r must be a string, got %s'
+        % (name, type(value).__name__))
+  return value
+
+
+def _get_optional_str(key: Dict, name: str) -> Optional[str]:
+  """Same contract as _get_required_str but returns None when absent."""
+  if name not in key:
+    return None
+  value = key[name]
+  if not isinstance(value, str):
+    raise tink.TinkError(
+        'invalid JWK: field %r must be a string, got %s'
+        % (name, type(value).__name__))
+  return value
+
+
 def _reject_duplicate_keys(pairs):
   """object_pairs_hook for json.loads that rejects duplicate JSON keys.
 
@@ -250,11 +281,17 @@ def to_public_keyset_handle(jwk_set: str) -> tink.KeysetHandle:
     raise tink.TinkError('error parsing JWK set: %s' % e.msg)
   if 'keys' not in keys_dict:
     raise tink.TinkError('invalid JWK set: keys not found')
+  if not isinstance(keys_dict['keys'], list):
+    raise tink.TinkError(
+        'invalid JWK set: "keys" must be a list, got %s'
+        % type(keys_dict['keys']).__name__)
   proto_keyset = tink_pb2.Keyset()
   for key in keys_dict['keys']:
-    if 'alg' not in key:
-      raise tink.TinkError('invalid JWK: alg not found')
-    alg = key['alg']
+    if not isinstance(key, dict):
+      raise tink.TinkError(
+          'invalid JWK: each entry of "keys" must be an object, got %s'
+          % type(key).__name__)
+    alg = _get_required_str(key, 'alg')
     if alg.startswith('ES'):
       proto_key = _convert_to_ecdsa_key(key)
     elif alg.startswith('RS'):
@@ -297,7 +334,7 @@ def _convert_to_ecdsa_key(
     key: Dict[str, Union[str, List[str]]]) -> tink_pb2.Keyset.Key:
   """Converts a EC Json Web Key (JWK) into a tink_pb2.Keyset.Key."""
   ecdsa_public_key = jwt_ecdsa_pb2.JwtEcdsaPublicKey()
-  algorithm = _ECDSA_NAME_TO_ALGORITHM.get(cast(str, key['alg']), None)
+  algorithm = _ECDSA_NAME_TO_ALGORITHM.get(_get_required_str(key, 'alg'), None)
   if not algorithm:
     raise tink.TinkError('unknown ECDSA algorithm')
   if key.get('kty', None) != 'EC':
@@ -309,10 +346,11 @@ def _convert_to_ecdsa_key(
   if 'd' in key:
     raise tink.TinkError('cannot convert private ECDSA key')
   ecdsa_public_key.algorithm = algorithm
-  ecdsa_public_key.x = _base64_decode(cast(str, key['x']))
-  ecdsa_public_key.y = _base64_decode(cast(str, key['y']))
-  if 'kid' in key:
-    ecdsa_public_key.custom_kid.value = key['kid']
+  ecdsa_public_key.x = _base64_decode(_get_required_str(key, 'x'))
+  ecdsa_public_key.y = _base64_decode(_get_required_str(key, 'y'))
+  kid = _get_optional_str(key, 'kid')
+  if kid is not None:
+    ecdsa_public_key.custom_kid.value = kid
   proto_key = tink_pb2.Keyset.Key()
   proto_key.key_data.type_url = _JWT_ECDSA_PUBLIC_KEY_TYPE
   proto_key.key_data.value = ecdsa_public_key.SerializeToString()
@@ -326,7 +364,8 @@ def _convert_to_rsa_ssa_pkcs1_key(
     key: Dict[str, Union[str, List[str]]]) -> tink_pb2.Keyset.Key:
   """Converts a JWK into a JwtEcdsaPublicKey."""
   public_key = jwt_rsa_ssa_pkcs1_pb2.JwtRsaSsaPkcs1PublicKey()
-  algorithm = _RSA_SSA_PKCS1_NAME_TO_ALGORITHM.get(cast(str, key['alg']), None)
+  algorithm = _RSA_SSA_PKCS1_NAME_TO_ALGORITHM.get(
+      _get_required_str(key, 'alg'), None)
   if not algorithm:
     raise tink.TinkError('unknown RSA SSA PKCS1 algorithm')
   if key.get('kty', None) != 'RSA':
@@ -336,10 +375,11 @@ def _convert_to_rsa_ssa_pkcs1_key(
       'qi' in key):
     raise tink.TinkError('importing RSA private keys is not implemented')
   public_key.algorithm = algorithm
-  public_key.n = _base64_decode(cast(str, key['n']))
-  public_key.e = _base64_decode(cast(str, key['e']))
-  if 'kid' in key:
-    public_key.custom_kid.value = key['kid']
+  public_key.n = _base64_decode(_get_required_str(key, 'n'))
+  public_key.e = _base64_decode(_get_required_str(key, 'e'))
+  kid = _get_optional_str(key, 'kid')
+  if kid is not None:
+    public_key.custom_kid.value = kid
   proto_key = tink_pb2.Keyset.Key()
   proto_key.key_data.type_url = _JWT_RSA_SSA_PKCS1_PUBLIC_KEY_TYPE
   proto_key.key_data.value = public_key.SerializeToString()
@@ -353,7 +393,8 @@ def _convert_to_rsa_ssa_pss_key(
     key: Dict[str, Union[str, List[str]]]) -> tink_pb2.Keyset.Key:
   """Converts a JWK into a JwtEcdsaPublicKey."""
   public_key = jwt_rsa_ssa_pss_pb2.JwtRsaSsaPssPublicKey()
-  algorithm = _RSA_SSA_PSS_NAME_TO_ALGORITHM.get(cast(str, key['alg']), None)
+  algorithm = _RSA_SSA_PSS_NAME_TO_ALGORITHM.get(
+      _get_required_str(key, 'alg'), None)
   if not algorithm:
     raise tink.TinkError('unknown RSA SSA PSS algorithm')
   if key.get('kty', None) != 'RSA':
@@ -363,10 +404,11 @@ def _convert_to_rsa_ssa_pss_key(
       'qi' in key):
     raise tink.TinkError('importing RSA private keys is not implemented')
   public_key.algorithm = algorithm
-  public_key.n = _base64_decode(cast(str, key['n']))
-  public_key.e = _base64_decode(cast(str, key['e']))
-  if 'kid' in key:
-    public_key.custom_kid.value = cast(str, key['kid'])
+  public_key.n = _base64_decode(_get_required_str(key, 'n'))
+  public_key.e = _base64_decode(_get_required_str(key, 'e'))
+  kid = _get_optional_str(key, 'kid')
+  if kid is not None:
+    public_key.custom_kid.value = kid
   proto_key = tink_pb2.Keyset.Key()
   proto_key.key_data.type_url = _JWT_RSA_SSA_PSS_PUBLIC_KEY_TYPE
   proto_key.key_data.value = public_key.SerializeToString()

--- a/tink/jwt/_jwk_set_converter_test.py
+++ b/tink/jwt/_jwk_set_converter_test.py
@@ -829,5 +829,59 @@ class JwkSetConverterTest(parameterized.TestCase):
     with self.assertRaises(tink.TinkError):
       jwt.jwk_set_to_public_keyset_handle(jwk_set)
 
+  @parameterized.parameters(
+      # Non-string "alg" — without _get_required_str, alg.startswith()
+      # raises AttributeError; documented exception is tink.TinkError only.
+      ('{"keys":[{"alg":null,"kty":"RSA","n":"AQAB","e":"AQAB"}]}',),
+      ('{"keys":[{"alg":{},"kty":"RSA","n":"AQAB","e":"AQAB"}]}',),
+      ('{"keys":[{"alg":42,"kty":"RSA","n":"AQAB","e":"AQAB"}]}',),
+      ('{"keys":[{"alg":[],"kty":"RSA","n":"AQAB","e":"AQAB"}]}',),
+      # Non-string "n" / "e" — _base64_decode would raise on .encode().
+      ('{"keys":[{"alg":"RS256","kty":"RSA","n":null,"e":"AQAB"}]}',),
+      ('{"keys":[{"alg":"RS256","kty":"RSA","n":42,"e":"AQAB"}]}',),
+      ('{"keys":[{"alg":"RS256","kty":"RSA","n":"AQAB","e":null}]}',),
+      ('{"keys":[{"alg":"PS256","kty":"RSA","n":"AQAB","e":{}}]}',),
+      # Non-string "x" / "y" on ECDSA path.
+      ('{"keys":[{"alg":"ES256","kty":"EC","crv":"P-256",'
+       '"x":null,"y":"AQAB"}]}',),
+      ('{"keys":[{"alg":"ES256","kty":"EC","crv":"P-256",'
+       '"x":"AQAB","y":42}]}',),
+      # Non-string "kid" on each algorithm family.
+      ('{"keys":[{"alg":"RS256","kty":"RSA","n":"AQAB","e":"AQAB",'
+       '"kid":42}]}',),
+      ('{"keys":[{"alg":"PS256","kty":"RSA","n":"AQAB","e":"AQAB",'
+       '"kid":{}}]}',),
+      ('{"keys":[{"alg":"ES256","kty":"EC","crv":"P-256",'
+       '"x":"AQAB","y":"AQAB","kid":[]}]}',),
+  )
+  def test_jwk_set_with_non_string_field_raises_tink_error(self, jwk_set):
+    with self.assertRaises(tink.TinkError):
+      jwt.jwk_set_to_public_keyset_handle(jwk_set)
+
+  @parameterized.parameters(
+      # "keys" must be a list; non-list types previously raised a TypeError
+      # from "for key in keys_dict['keys']" (on dict it iterates keys, on
+      # int/None it raises TypeError leaking the type into the stack trace).
+      ('{"keys":"not-a-list"}',),
+      ('{"keys":42}',),
+      ('{"keys":null}',),
+      ('{"keys":{"a":"b"}}',),
+  )
+  def test_jwk_set_with_non_list_keys_field_raises_tink_error(self, jwk_set):
+    with self.assertRaises(tink.TinkError):
+      jwt.jwk_set_to_public_keyset_handle(jwk_set)
+
+  @parameterized.parameters(
+      # Each entry of "keys" must be a JSON object; non-objects previously
+      # leaked TypeError from the alg lookup.
+      ('{"keys":["not-a-key"]}',),
+      ('{"keys":[null]}',),
+      ('{"keys":[42]}',),
+      ('{"keys":[[]]}',),
+  )
+  def test_jwk_set_with_non_object_key_entry_raises_tink_error(self, jwk_set):
+    with self.assertRaises(tink.TinkError):
+      jwt.jwk_set_to_public_keyset_handle(jwk_set)
+
 if __name__ == '__main__':
   absltest.main()

--- a/tink/jwt/_jwk_set_converter_test.py
+++ b/tink/jwt/_jwk_set_converter_test.py
@@ -807,5 +807,27 @@ class JwkSetConverterTest(parameterized.TestCase):
     with self.assertRaises(tink.TinkError):
       jwt.jwk_set_to_public_keyset_handle('invalid')
 
+  @parameterized.parameters(
+      # Duplicate "alg" — Python stdlib json silently picks second occurrence
+      # (last-wins); sibling Tink ports (tink-cc/tink-go/tink-java) reject
+      # via protobuf JSON parser. This brings tink-py to documented parity.
+      ('{"keys":[{"alg":"none","alg":"PS256","kty":"RSA",'
+       '"n":"AAAA","e":"AAAA"}]}',),
+      # Duplicate "kid"
+      ('{"keys":[{"alg":"PS256","kty":"RSA","n":"AAAA","e":"AAAA",'
+       '"kid":"victim_kid","kid":"attacker_kid"}]}',),
+      # Duplicate "kty" (first "EC", second "RSA")
+      ('{"keys":[{"alg":"PS256","kty":"EC","kty":"RSA",'
+       '"n":"AAAA","e":"AAAA"}]}',),
+      # Duplicate "n"
+      ('{"keys":[{"alg":"PS256","kty":"RSA","n":"AA","n":"AAAA",'
+       '"e":"AAAA"}]}',),
+      # Duplicate "keys" at top level
+      ('{"keys":[],"keys":[]}',),
+  )
+  def test_jwk_set_with_duplicate_json_keys_raises_tink_error(self, jwk_set):
+    with self.assertRaises(tink.TinkError):
+      jwt.jwk_set_to_public_keyset_handle(jwk_set)
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
## Summary

Python's stdlib `json.loads()` silently accepts duplicate JSON object keys per CPython last-value-wins behavior. The sibling Tink ports (`tink-cc`, `tink-go`, `tink-java`) all use protobuf JSON parsers that strict-reject duplicate keys per RFC 8259 best practice.

This means a JWK Set such as

```json
{"keys":[{"alg":"none","alg":"PS256","kty":"RSA","n":"AAAA","e":"AAAA"}]}
```

is rejected by `tink-go` (`proto: ... duplicate map key`), tink-cc, and tink-java, but **silently accepted** by tink-py with the last-occurrence value taking effect (`alg=PS256` in the example above).

This is the same class of cross-implementation parser disagreement that has been the root of JOSE / JWK auth-confusion CVEs (e.g., CVE-2018-0114). It is exposed in deployments where tink-py is downstream of a sibling-port pre-validator: a JWK Set that the strict parser would reject can carry a *different effective field value* (`kid`, `n`, `alg`, `kty`, …) when interpreted by tink-py.

I confirmed the divergence on HEAD with the differential fuzzer at https://github.com/ibondarenko1/tink-cross-port-fuzz (atheris-driven, JWK Set surface). Reproducer corpus is in `corpus_jwk/17_*.json` … `19_*.json` of that repo plus the inline test cases in this PR.

## Changes

- `tink/jwt/_jwk_set_converter.py` — pass `object_pairs_hook=_reject_duplicate_keys` to `json.loads`. The hook raises `tink.TinkError` if a duplicate key is seen.
- `tink/jwt/_jwk_set_converter_test.py` — parameterized tests for duplicate `alg`, `kid`, `kty`, `n`, and top-level `keys`.

After the patch, all four ports agree on the accept/reject decision for the affected inputs.

## Test plan

- [x] New parameterized tests pass locally (`test_jwk_set_with_duplicate_json_keys_raises_tink_error`)
- [x] Existing tests untouched
- [ ] CI: `pytest tink/jwt/_jwk_set_converter_test.py`