### PR TITLE
fix(gcpkms): verify CRC32C integrity on Encrypt and Decrypt responses

### DIFF
--- a/requirements_gcpkms.in
+++ b/requirements_gcpkms.in
@@ -1,3 +1,4 @@
 google-auth>=2.38.0
 google-api-core>=2.24.2
 google-cloud-kms>=3.4.1
+google-crc32c>=1.5.0

--- a/tink/integration/gcpkms/BUILD.bazel
+++ b/tink/integration/gcpkms/BUILD.bazel
@@ -23,6 +23,7 @@ py_library(
         requirement("google-auth"),
         requirement("google-api-core"),
         requirement("google-cloud-kms"),
+        requirement("google-crc32c"),
     ],
 )
 

--- a/tink/integration/gcpkms/_gcp_kms_client.py
+++ b/tink/integration/gcpkms/_gcp_kms_client.py
@@ -20,9 +20,20 @@ from google.api_core import exceptions as core_exceptions
 from google.auth import credentials as auth_credentials
 from google.cloud import kms_v1
 from google.oauth2 import service_account
+import google_crc32c
 
 import tink
 from tink import aead
+
+
+def _crc32c(data: bytes) -> int:
+  """CRC32C checksum of `data` as an int.
+
+  The Cloud KMS request/response protobuf fields use
+  google.protobuf.Int64Value for crc32c values. The Python google-cloud-kms
+  client accepts a plain int for those fields.
+  """
+  return int.from_bytes(google_crc32c.Checksum(data).digest(), 'big')
 
 GCP_KEYURI_PREFIX = 'gcp-kms://'
 _KMS_KEY_REGEX = re.compile(
@@ -63,19 +74,59 @@ class _GcpKmsAead(aead.Aead):
     self.key_version_specified = bool(_KMS_KEY_VERSION_REGEX.match(key_name))
 
   def encrypt(self, plaintext: bytes, associated_data: bytes) -> bytes:
+    """Encrypts `plaintext` with `associated_data` via Cloud KMS.
+
+    Verifies request and response integrity per Cloud KMS Data Integrity
+    Guidelines (https://cloud.google.com/kms/docs/data-integrity-guidelines):
+    sets request CRC32C fields, then fails closed if the response indicates
+    the server did not verify the request, or if the returned ciphertext
+    CRC32C does not match the locally recomputed checksum.
+    """
     try:
       response = self.client.encrypt(
           request=kms_v1.types.service.EncryptRequest(
               name=self.name,
               plaintext=plaintext,
+              plaintext_crc32c=_crc32c(plaintext),
               additional_authenticated_data=associated_data,
+              additional_authenticated_data_crc32c=_crc32c(associated_data),
           )
       )
-      return response.ciphertext
+      if not response.verified_plaintext_crc32c:
+        raise tink.TinkError(
+            'Cloud KMS request for {} is missing the checksum field '
+            'plaintext_crc32c, and other information may be missing from the '
+            'response. Please retry a limited number of times in case the '
+            'error is transient.'.format(self.name)
+        )
+      if not response.verified_additional_authenticated_data_crc32c:
+        raise tink.TinkError(
+            'Cloud KMS request for {} is missing the checksum field '
+            'additional_authenticated_data_crc32c, and other information may '
+            'be missing from the response. Please retry a limited number of '
+            'times in case the error is transient.'.format(self.name)
+        )
+      ciphertext = response.ciphertext
+      if response.ciphertext_crc32c != _crc32c(ciphertext):
+        raise tink.TinkError(
+            'Cloud KMS response corrupted in transit for {}: the checksum in '
+            'field ciphertext_crc32c did not match the data in field '
+            'ciphertext. Please retry in case this is a transient error.'
+            .format(self.name)
+        )
+      return ciphertext
     except core_exceptions.GoogleAPIError as e:
       raise tink.TinkError(e)
 
   def decrypt(self, ciphertext: bytes, associated_data: bytes) -> bytes:
+    """Decrypts `ciphertext` with `associated_data` via Cloud KMS.
+
+    Verifies request and response integrity per Cloud KMS Data Integrity
+    Guidelines: sets request CRC32C fields, then fails closed if the
+    response indicates the server did not verify the request, or if the
+    returned plaintext CRC32C does not match the locally recomputed
+    checksum.
+    """
     if self.key_version_specified:
       raise tink.TinkError(
           'A CryptoKeyVersion was specified. Decryption is only supported when '
@@ -86,10 +137,34 @@ class _GcpKmsAead(aead.Aead):
          request=kms_v1.types.service.DecryptRequest(
              name=self.name,
              ciphertext=ciphertext,
-             additional_authenticated_data=associated_data
+             ciphertext_crc32c=_crc32c(ciphertext),
+             additional_authenticated_data=associated_data,
+             additional_authenticated_data_crc32c=_crc32c(associated_data),
          )
       )
-      return response.plaintext
+      if not response.verified_ciphertext_crc32c:
+        raise tink.TinkError(
+            'Cloud KMS request for {} is missing the checksum field '
+            'ciphertext_crc32c, and other information may be missing from '
+            'the response. Please retry a limited number of times in case '
+            'the error is transient.'.format(self.name)
+        )
+      if not response.verified_additional_authenticated_data_crc32c:
+        raise tink.TinkError(
+            'Cloud KMS request for {} is missing the checksum field '
+            'additional_authenticated_data_crc32c, and other information may '
+            'be missing from the response. Please retry a limited number of '
+            'times in case the error is transient.'.format(self.name)
+        )
+      plaintext = response.plaintext
+      if response.plaintext_crc32c != _crc32c(plaintext):
+        raise tink.TinkError(
+            'Cloud KMS response corrupted in transit for {}: the checksum in '
+            'field plaintext_crc32c did not match the data in field '
+            'plaintext. Please retry in case this is a transient error.'
+            .format(self.name)
+        )
+      return plaintext
     except core_exceptions.GoogleAPIError as e:
       raise tink.TinkError(e)
 


### PR DESCRIPTION
## Background

The Python tink-py Cloud KMS adapter (`tink/integration/gcpkms/_gcp_kms_client.py`) was missing CRC32C integrity verification entirely on both `encrypt` and `decrypt`, in violation of the [Cloud KMS Data Integrity Guidelines](https://cloud.google.com/kms/docs/data-integrity-guidelines).

Sibling ports either already implement these gates or have follow-up PRs open:
- tink-go-gcpkms: [PR #21](https://github.com/tink-crypto/tink-go-gcpkms/pull/21) (Decrypt)
- tink-cc-gcpkms: [PR #2](https://github.com/tink-crypto/tink-cc-gcpkms/pull/2) (Decrypt) + [PR #3](https://github.com/tink-crypto/tink-cc-gcpkms/pull/3) (Encrypt)
- tink-java-gcpkms: follow-up PR coming

The Python port had **neither request CRC setting NOR response verification** on either direction — the most exposed of any tink port.

## Change

`encrypt` now:
1. Sets `plaintext_crc32c` and `additional_authenticated_data_crc32c` on the request.
2. Fails closed on any of:
   - `!response.verified_plaintext_crc32c`
   - `!response.verified_additional_authenticated_data_crc32c`
   - `response.ciphertext_crc32c != recomputed_crc32c(ciphertext)`

`decrypt` now:
1. Sets `ciphertext_crc32c` and `additional_authenticated_data_crc32c` on the request.
2. Fails closed on any of:
   - `!response.verified_ciphertext_crc32c`
   - `!response.verified_additional_authenticated_data_crc32c`
   - `response.plaintext_crc32c != recomputed_crc32c(plaintext)`

Adds `google-crc32c>=1.5.0` to `requirements_gcpkms.in` and to the `BUILD.bazel` deps for `_gcp_kms_client`. (`google-crc32c` is already a transitive dependency of `google-cloud-kms` but is now declared explicitly because tink-py uses it directly.)

## Why this is worth filing as one consolidated PR (not split per direction)

Unlike Go and C++ where one direction was already partially in place, the Python adapter had no CRC32C handling on either direction. Splitting would leave half the integrity gap open in any intermediate state.

## Reference

- [Cloud KMS Data Integrity Guidelines](https://cloud.google.com/kms/docs/data-integrity-guidelines)
- Sibling Go PR (Decrypt only): https://github.com/tink-crypto/tink-go-gcpkms/pull/21
- Sibling C++ PR (Decrypt): https://github.com/tink-crypto/tink-cc-gcpkms/pull/2
- Sibling C++ PR (Encrypt): https://github.com/tink-crypto/tink-cc-gcpkms/pull/3