### PR TITLE
Distribute type information per PEP 561 (fixes #22)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,9 @@ def main() -> None:
       long_description_content_type='text/markdown',
       # Contained modules and scripts.
       packages=setuptools.find_packages(),
+      # PEP 561: ship the py.typed marker so type checkers pick up the
+      # inline annotations in the installed package.
+      package_data={'tink': ['py.typed']},
       install_requires=_parse_requirements('requirements.in'),
       extras_require={
           'gcpkms': gcpkms_extra_requirements,


### PR DESCRIPTION
## Summary
- Adds an empty `tink/py.typed` marker so type checkers see the inline annotations in the installed package (PEP 561).
- Ships the marker in wheels via `package_data={'tink': ['py.typed']}` in `setup.py`. `MANIFEST.in` already grafts `tink/`, so sdists pick it up.

Fixes #22.

## Test plan
- [ ] Build a wheel and confirm `tink/py.typed` is inside it.
- [ ] In a downstream project, import `tink` and run `mypy`. The "missing imports" errors should go away without a `mypy.ini` override.