### PR TITLE
Hide internal C++ symbols in Mac OS builds for libprotobuf compatibility

### DIFF
--- a/tink/cc/pybind/BUILD.bazel
+++ b/tink/cc/pybind/BUILD.bazel
@@ -265,6 +265,10 @@ _PYBIND_EXTENSION_DEPS = [
 pybind_extension(
     name = "tink_bindings",
     srcs = ["tink_bindings.cc"],
+    linkopts = select({
+        "@platforms//os:macos": ["-Wl,-exported_symbol,_PyInit_tink_bindings"],
+        "//conditions:default": [],
+    }),
     deps = _PYBIND_EXTENSION_DEPS,
 )
 

--- a/tink/cc/pybind/BUILD.bazel
+++ b/tink/cc/pybind/BUILD.bazel
@@ -266,6 +266,14 @@ pybind_extension(
     name = "tink_bindings",
     srcs = ["tink_bindings.cc"],
     linkopts = select({
+        # Clang on Mac OS makes all static symbols global weak symbols by default.
+        # This flag ensures that the Python interpreter only loads in the PyInit
+        # symbol, turning the global weak symbols into locals. This prevents clashes
+        # between static variable initializers coming from one version of libprotobuf,
+        # and the runtime code coming from another.
+        # See the following GitHub links for relevant discussion:
+        # https://github.com/grpc/grpc/pull/24992
+        # https://github.com/protocolbuffers/protobuf/pull/8346
         "@platforms//os:macos": ["-Wl,-exported_symbol,_PyInit_tink_bindings"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
This PR makes it so that the protobuf runtime Tink uses internally isn't exposed to the Python interpreter. It's a spiritual equivalent of https://github.com/grpc/grpc/pull/24992. At a high level, this stops leaking tink's internal C++ protobuf usage to the Python interpreter. This allows other Python projects which use a different protobuf version than the one Tink was built with to peacefully coexist with Tink.

Technical details: This change avoids Clang on Mac OS exporting all symbols as global weak symbols in the generated .so (which may cause issues with dynamic linking). We don't have this corresponding problem on other architectures or operating systems - as far as I've read online, this is a Mach O specific issue.

Since this is my first contribution to tink-py, please let me know if there's more due diligence needed to land other than the test plan below to verify correctness.

Tests:

* Ran `bazel test ...`.

* The `.so` now only exports one symbol: `bazel build -- //tink/cc/pybind:tink_bindings && nm --extern-only --defined-only bazel-bin/tink/cc/pybind/tink_bindings.so` marks exactly _PyInit_tink_bindings as an exported symbol (as opposed to over 30k symbols on main on my machine).

* Ran `sh ./kokoro/macos_external/pip/run_tests.sh`

* Created a venv that downloaded tink's dependencies, and ran `python -m pip install --no-deps code/tink-py` with a protoc 33.6 compiler. Used this to run the following python script I placed under `test.py`:

```
import tink
from tink import aead

aead.register()

primitive = tink.new_keyset_handle(
    aead.aead_key_templates.AES128_GCM
).primitive(aead.Aead)

ciphertext = primitive.encrypt(b"hello", b"aad")
assert primitive.decrypt(ciphertext, b"aad") == b"hello"

print("tink import and AEAD use succeeded")
```

It prints the succeed as expected.